### PR TITLE
Trimear nombre antes de guardarlo

### DIFF
--- a/src/app/solicitar-ayuda/_components/Form/FormContainer.tsx
+++ b/src/app/solicitar-ayuda/_components/Form/FormContainer.tsx
@@ -33,7 +33,7 @@ export function FormContainer() {
   const session = useSession();
 
   const [formData, setFormData] = useState<FormData>({
-    nombre: session?.user?.user_metadata?.full_name || '',
+    nombre: session?.user?.user_metadata?.full_name.split(" ")[0]|| '',
     ubicacion: '',
     coordinates: null,
     tiposDeAyuda: new Map(TIPOS_DE_AYUDA.map(({ id }) => [id, false])),
@@ -91,7 +91,7 @@ export function FormContainer() {
       try {
         const helpRequestData: Database['public']['Tables']['help_requests']['Insert'] = {
           type: 'necesita',
-          name: formData.nombre,
+          name: formData.nombre.split(" ")[0],
           location: formData.ubicacion,
           latitude: formData.coordinates ? parseFloat(formData.coordinates.lat) : null,
           longitude: formData.coordinates ? parseFloat(formData.coordinates.lng) : null,

--- a/src/app/solicitar-ayuda/_components/Form/FormRenderer.tsx
+++ b/src/app/solicitar-ayuda/_components/Form/FormRenderer.tsx
@@ -61,7 +61,7 @@ export function FormRenderer({
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Nombre completo</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
               <input
                 type="text"
                 name="nombre"

--- a/src/components/SolicitudCard.tsx
+++ b/src/components/SolicitudCard.tsx
@@ -160,7 +160,7 @@ export default function SolicitudCard({
             </svg>
           </div>
           <div className="flex-auto">
-            <div className="text-lg font-medium">{caso.name || 'Necesita Ayuda'}</div>
+            <div className="text-lg font-medium">{caso?.name?.split(" ")[0] || 'Necesita Ayuda'}</div>
             <span className="text-gray-500">
               {new Date(caso.created_at!).toLocaleDateString() +
                 ' ' +


### PR DESCRIPTION
### Changes

When adding new ask for help, the form will ask for just your `name`, if full name its passed would be trimmed to just one word and then persist it in supabase.

We already have full names in the db, and for this in case of rendering just show first word in name when showing help card.

### Testing

try to break it !

1. Create a new need for help (solicitar ayuda) and try to put a really long name. See how its saved un supabase and also how its showed in active cases
2. With your user that already have a long name try to request for help, see just your first name coming.

### Concerns

Name cleanup should happen in supabase
Ayudas ofrecidas should have same name pattern

### Trello link
[Issue](https://trello.com/c/zKffpib4) 