### PR TITLE
feat(helpRequests): Delete expired records and send email notice

### DIFF
--- a/src/components/HelpOffers/HelpOfferForm.tsx
+++ b/src/components/HelpOffers/HelpOfferForm.tsx
@@ -8,6 +8,7 @@ import { Town } from '@/types/Town';
 import Unauthorized from '@/components/Unauthorized';
 import { useTowns } from '@/context/TownProvider';
 import { toast } from 'sonner';
+import { InfoIcon } from 'lucide-react';
 
 export type HelpOfferFormData = {
   aceptaProtocolo: boolean;
@@ -269,6 +270,15 @@ export default function HelpOfferForm({ data, buttonText, submitMutation }: Help
         >
           {buttonText[0]}
         </button>
+      </div>
+
+
+      <div className="mt-6 flex items-start gap-4">
+        <InfoIcon className="h-6 w-6 text-blue-400 flex-shrink-0" />
+        <div>
+          <p className="text-sm text-gray-700">Las ofertas de ayuda se borrarán automáticamente a los 7 días.
+            Si lo deseas, tras este plazo puedes crear una nueva oferta con datos actualizados.</p>
+        </div>
       </div>
     </form>
   );

--- a/src/components/HelpOffers/HelpOfferForm.tsx
+++ b/src/components/HelpOffers/HelpOfferForm.tsx
@@ -272,12 +272,13 @@ export default function HelpOfferForm({ data, buttonText, submitMutation }: Help
         </button>
       </div>
 
-
       <div className="mt-6 flex items-start gap-4">
         <InfoIcon className="h-6 w-6 text-blue-400 flex-shrink-0" />
         <div>
-          <p className="text-sm text-gray-700">Las ofertas de ayuda se borrarán automáticamente a los 7 días.
-            Si lo deseas, tras este plazo puedes crear una nueva oferta con datos actualizados.</p>
+          <p className="text-sm text-gray-700">
+            Las ofertas de ayuda se borrarán automáticamente a los 7 días. Si lo deseas, tras este plazo puedes crear
+            una nueva oferta con datos actualizados.
+          </p>
         </div>
       </div>
     </form>

--- a/src/components/HelpRequests/HelpRequestForm.tsx
+++ b/src/components/HelpRequests/HelpRequestForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
+import React, { ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
 import { isValidPhone } from '@/helpers/utils';
 import { tiposAyudaArray } from '@/helpers/constants';
 import { PhoneInput } from '@/components/input/PhoneInput';
@@ -11,6 +11,7 @@ import AddressMap, { AddressDescriptor } from '@/components/AddressMap';
 import { LngLat } from '@/components/map/GeolocationMap';
 import { useSession } from '@/context/SessionProvider';
 import Unauthorized from '@/components/Unauthorized';
+import { AlertCircle, InfoIcon } from 'lucide-react';
 
 export type HelpRequestFormData = {
   nombre: string;
@@ -274,6 +275,14 @@ export default function HelpRequestForm({
       >
         {isSubmitting ? buttonText[1] : buttonText[0]}
       </button>
+
+      <div className="pb-3 flex gap-4">
+        <InfoIcon className="h-6 w-6 text-blue-400 flex-shrink-0" />
+        <div>
+          <p className="text-sm text-gray-700">Las solicitudes de ayuda se borrarán automáticamente a los 7 días.
+            Si tras este plazo sigues necesitando ayuda, crea una nueva solicitud con datos actualizados.</p>
+        </div>
+      </div>
     </form>
   );
 }

--- a/src/components/HelpRequests/HelpRequestForm.tsx
+++ b/src/components/HelpRequests/HelpRequestForm.tsx
@@ -279,8 +279,10 @@ export default function HelpRequestForm({
       <div className="pb-3 flex gap-4">
         <InfoIcon className="h-6 w-6 text-blue-400 flex-shrink-0" />
         <div>
-          <p className="text-sm text-gray-700">Las solicitudes de ayuda se borrarán automáticamente a los 7 días.
-            Si tras este plazo sigues necesitando ayuda, crea una nueva solicitud con datos actualizados.</p>
+          <p className="text-sm text-gray-700">
+            Las solicitudes de ayuda se borrarán automáticamente a los 7 días. Si tras este plazo sigues necesitando
+            ayuda, crea una nueva solicitud con datos actualizados.
+          </p>
         </div>
       </div>
     </form>

--- a/supabase/migrations/20241109135051_delete_expired_records.sql
+++ b/supabase/migrations/20241109135051_delete_expired_records.sql
@@ -45,7 +45,8 @@ begin
       and h.created_at >= now() - interval '7 days'
       and h.expiry_notice_sent = false
       and h.status = 'active'
-      and h.type = 'necesita';
+      and h.type = 'necesita'
+      limit 50;
 
     -- If there are no emails to send, do nothing
     if email_list is null then
@@ -105,7 +106,8 @@ begin
     where h.created_at < now() - interval '6 days'
       and h.created_at >= now() - interval '7 days'
       and h.expiry_notice_sent = false
-      and h.type = 'ofrece';
+      and h.type = 'ofrece'
+      limit 50;
 
     -- If there are no emails to send, do nothing
     if email_list is null then

--- a/supabase/migrations/20241109135051_delete_expired_records.sql
+++ b/supabase/migrations/20241109135051_delete_expired_records.sql
@@ -1,0 +1,148 @@
+create extension if not exists pg_cron with schema extensions;
+create extension if not exists http with schema extensions;
+
+grant usage on schema cron to postgres;
+grant all privileges on all tables in schema cron to postgres;
+
+select cron.schedule (
+    'delete_expired_records', -- name of the cron job
+    '0 4 * * *', -- Every day at 4:00am (GMT)
+    $$ delete from public.help_requests where created_at < now() - interval '7 days'; $$
+);
+
+alter table public.help_requests add column expiry_notice_sent boolean default false;
+
+create index if not exists idx_help_requests_created_at on public.help_requests using btree (created_at, expiry_notice_sent, type);
+
+create or replace function send_request_expiry_notices() returns void as $$
+declare
+    api_key text;
+    email_body text;
+    email_list text[];
+    help_request_ids bigint[];
+    status_code int;
+begin
+    -- Get the RESEND_API_KEY
+    select decrypted_secret into api_key
+    from vault.decrypted_secrets
+    where name = 'RESEND_API_KEY'
+    limit 1;
+
+    -- If the API key is not found, do nothing
+    if api_key is null then
+        return;
+    end if;
+
+    -- Construct the email body
+    email_body := 'Tu solicitud de ayuda en ajudadana.es caducará en 1 día y será eliminada automáticamente. Si todavía necesitas ayuda, considera crear una solicitud nueva con datos actualizados.';
+
+    -- Collect email addresses and help request IDs
+    select array_agg(u.email), array_agg(h.id)
+    into email_list, help_request_ids
+    from public.help_requests h
+    join auth.users u on h.user_id = u.id
+    where h.created_at < now() - interval '6 days'
+      and h.created_at >= now() - interval '7 days'
+      and h.expiry_notice_sent = false
+      and h.status = 'active'
+      and h.type = 'necesita';
+
+    -- If there are no emails to send, do nothing
+    if email_list is null then
+        return;
+    end if;
+
+    -- Send the email using the resend API
+    select status into status_code from http((
+      'POST',
+      'https://api.resend.com/emails',
+      array[http_header('Authorization','Bearer ' || api_key)],
+      'application/json',
+      '{
+        "from": "Ajudadana <info@ajudadana.es>",
+        "to": ["' || array_to_string(email_list, '","') || '"],
+        "subject": "Tu solicitud en Ajudadana.es será eliminada",
+        "html": "<p>' || email_body || '</p>"
+      }'
+    )::http_request);
+
+    if status_code <> 200 then
+       return;
+    end if;
+
+    -- Update the help requests to mark the expiry notice as sent
+    update help_requests set expiry_notice_sent = true where id = any(help_request_ids);
+end;
+$$ language plpgsql;
+
+create or replace function send_offer_expiry_notices() returns void as $$
+declare
+    api_key text;
+    email_body text;
+    email_list text[];
+    help_request_ids bigint[];
+    status_code int;
+begin
+    -- Get the RESEND_API_KEY
+    select decrypted_secret into api_key
+    from vault.decrypted_secrets
+    where name = 'RESEND_API_KEY'
+    limit 1;
+
+    -- If the API key is not found, do nothing
+    if api_key is null then
+        return;
+    end if;
+
+    -- Construct the email body
+    email_body := 'Tu oferta de ayuda en ajudadana.es caducará en 1 día y será eliminada automáticamente. Si lo deseas, crea una oferta de ayuda nueva con datos actualizados.';
+
+    -- Collect email addresses and help request IDs
+    select array_agg(u.email), array_agg(h.id)
+    into email_list, help_request_ids
+    from public.help_requests h
+    join auth.users u on h.user_id = u.id
+    where h.created_at < now() - interval '6 days'
+      and h.created_at >= now() - interval '7 days'
+      and h.expiry_notice_sent = false
+      and h.type = 'ofrece';
+
+    -- If there are no emails to send, do nothing
+    if email_list is null then
+        return;
+    end if;
+
+    -- Send the email using the resend API
+    select status into status_code from http((
+      'POST',
+      'https://api.resend.com/emails',
+      array[http_header('Authorization','Bearer ' || api_key)],
+      'application/json',
+      '{
+        "from": "Ajudadana <info@ajudadana.es>",
+        "to": ["' || array_to_string(email_list, '","') || '"],
+        "subject": "Tu oferta de ayuda en Ajudadana.es será eliminada",
+        "html": "<p>' || email_body || '</p>"
+      }'
+    )::http_request);
+
+    if status_code <> 200 then
+       return;
+    end if;
+
+    -- Update the help requests to mark the expiry notice as sent
+    update help_requests set expiry_notice_sent = true where id = any(help_request_ids);
+end;
+$$ language plpgsql;
+
+select cron.schedule (
+    'send_request_expiry_notices', -- name of the cron job
+    '*/10 * * * *', -- Every ten minutes
+    $$ select public.send_request_expiry_notices(); $$
+);
+
+select cron.schedule (
+    'send_offer_expiry_notices', -- name of the cron job
+    '5-59/10 * * * *', -- Every ten minutes
+    $$ select public.send_offer_expiry_notices(); $$
+);


### PR DESCRIPTION
CUIDADO: Después de mergear esto todas las noches se borrarán automáticamente las solicitudes/ofertas más antiguas que 7 días.

- Añadido cron que borra todas las filas de help_requests más antiguas que 7 días.
- Añadidos avisos de que se borrarán las solicitudes/ofertas a los 7 días en los respectivos formularios.
- Añadidos crons para mandar emails de aviso de expiración a los 6 días.

## Cómo hacer que funcione el envío de emails:
Hay que abrir una cuenta de Resend para prod, verificar el dominio de ajudadana.es en Resend, crear una API key y meterla en el Vault de supabase con el nombre `RESEND_API_KEY`.
Si la api key no está, los cron jobs de envío de emails hacen return pronto y ya está. Estarían "desactivados".
Por lo tanto esto se puede mergear aunque haya que hacer cambios en los cron jobs de los emails, a fin de que los help_requests se empiecen a borrar automáticamente ya.

## IMPORTANTE: Consideraciones
1. Servicio de emails: Como no tenemos integrado ningún servicio de email, he usado Resend, que es recomendado por Supabase y está guay. Dicho esto, es posible que queráis usar un servicio más barato como SNS. Up to you. En ese caso se podrían modificar las funciones que envían los emails para que llamen a otra API.
2. Cron jobs, background jobs: No hay una manera de definirlos y ejecutarlos en nuestra aplicación, como haría falta para sean testeables, mantenibles y extensibles a nivel de usar librerías, agregar templates a los emails, funcionalidad un poco más compleja, etc. Para sacar la funcionalidad adelante que parece que el tiempo apremia, he metido tanto el borrado automático (esto me parece bien) como el envío de notificaciones por el borrado (esto creo que hay que mejorarlo) en cron jobs y funciones de postgres/supabase. Lo suyo sería poder definir todo esto en typescript, igual que el resto de la aplicación. No tengo 100% claro cómo es la infraestructura en prod hoy en día pero según tengo entendido la aplicación Next está en Vercel y por la naturaleza serverless de cómo se hostea Next en Vercel no es un lugar adecuado ni para poner cron jobs ni para poner endpoints que inicien una tarea asíncrona (que se puedan llamar sin tener que esperar a la respuesta). Creo que la solución con la infra actual (si no me he perdido de mucho) es usar cron jobs / edge functions de Vercel o supabase. Pero sin acceso a un entorno parecido a prod es difícil de desarrollar.
